### PR TITLE
Use better names for GitHub Actions.

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -2,13 +2,11 @@ name: Terraform
 
 on:
   push:
-  pull_request:
-    branches:
-      - main
 
 jobs:
-  terraform:
-    name: Terraform
+  plan:
+    name: Plan
+    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -43,8 +41,41 @@ jobs:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
           TF_VAR_heroku_basename: ${{ secrets.TF_VAR_heroku_basename }}
 
+  apply:
+    name: Apply
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Cache installed terraform providers
+        uses: actions/cache@v3
+        with:
+          path: terraform/.terraform
+          key: v1-${{ hashFiles('terraform/.terraform.lock.hcl') }}
+
+      - name: Initialize terraform
+        run: docker compose run terraform init
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          TF_VAR_heroku_basename: ${{ secrets.TF_VAR_heroku_basename }}
+
+      - name: Plan infrastructure changes
+        run: docker compose run terraform plan -out planned
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          TF_VAR_heroku_basename: ${{ secrets.TF_VAR_heroku_basename }}
+
       - name: Apply infrastructure changes
-        if: ${{ github.ref == 'refs/heads/main' }}
         run: docker compose run terraform apply planned
         env:
           AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
Updates the reported names in GitHub Actions to be `Terraform / Plan` and `Terraform / Apply`.